### PR TITLE
Added Default message in Length Rule

### DIFF
--- a/src/Rules/Length.php
+++ b/src/Rules/Length.php
@@ -40,6 +40,6 @@ class Length implements RuleInterface
      */
     public function message()
     {
-        // TODO: Implement message() method.
+        return '{$field} must match the requirements';
     }
 }


### PR DESCRIPTION
Default message was missing in the Length Rule, so added the default string in the message method.